### PR TITLE
add support for rclone cache remotes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 MAINTAINER tynor88 <tynor@hotmail.com>
 
 # global environment settings
-ENV RCLONE_VERSION="current"
+ENV RCLONE_DOWNLOAD_VERSION="current"
 ENV PLATFORM_ARCH="amd64"
 
 # s6 environment settings
@@ -34,8 +34,8 @@ RUN \
 	/tmp/s6-overlay.tar.gz -C / && \
 
  cd tmp && \
- wget -q http://downloads.rclone.org/rclone-${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
- unzip /tmp/rclone-${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
+ wget -q http://downloads.rclone.org/rclone-${RCLONE_DOWNLOAD_VERSION}-linux-${PLATFORM_ARCH}.zip && \
+ unzip /tmp/rclone-${RCLONE_DOWNLOAD_VERSION}-linux-${PLATFORM_ARCH}.zip && \
  mv /tmp/rclone-*-linux-${PLATFORM_ARCH}/rclone /usr/bin && \
 
  apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/community \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN \
 	usermod -G users abc && \
 
 # create some files / folders
-	mkdir -p /config /data && \
+	mkdir -p /config /data /tmpdata && \
 	mkdir -p /root/.cache/rclone/cache-backend
 
 # add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN \
 	usermod -G users abc && \
 
 # create some files / folders
-	mkdir -p /config /data
+	mkdir -p /config /data && \
+	mkdir -p /root/.cache/rclone/cache-backend
 
 # add local files
 COPY root/ /

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -4,5 +4,6 @@
 touch /config/.rclone.conf
 
 # permissions
-chown abc:abc \
-	/config/.rclone.conf
+chown -R abc:abc \
+	/config/.rclone.conf \
+	/root


### PR DESCRIPTION
This fixes a missing path for cache remotes. With this change I was able to successfully set up a remote + cache + crypt flow.